### PR TITLE
Don't depend on deprecated "gcc" crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/tomaka/ogg-sys"
 libc = "*"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 pkg-config = "0.3"


### PR DESCRIPTION
gcc has transferred to https://github.com/rust-lang/cc-rs and the old package was deprecated.